### PR TITLE
Readme: Add URL to Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Neuss Cycling Quality
 
-Porting the amazing [www.osm-verkehrswende.org](https://www.osm-verkehrswende.org/) Cycling Quality Index to Neuss
+Porting the amazing [www.osm-verkehrswende.org](https://www.osm-verkehrswende.org/) Cycling Quality Index to Neuss: https://ckrey.de/neuss-cycling-quality/
 
 Based on the code by [@SupaplexOSM](https://github.com/SupaplexOSM) and [@tordans](https://github.com/tordans) and [@Findus23](https://github.com/Findus23/vienna-cycling-quality)


### PR DESCRIPTION
Die URL zu https://ckrey.de/neuss-cycling-quality/?mode=cqi&map=11.5%2F6.7%2F51.192&filters=usable-yes fehlte bisher.

In der Sidebar des Projekten [auf Github](https://github.com/ckrey/neuss-cycling-quality) steht auch noch die URL von Wien, die könntest du auch aktualisieren.